### PR TITLE
[README] Add memorybacking section to reduce memory consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ To enable debug in ovs inside the container, you can run the following command i
     <driver queues='8'/>
     ```
 
+  - Add memoryBacking section to reduce memory consumed by ovs-vswitchd thread inside the docker: 
+    ```
+    <memoryBacking>
+    <hugepages>
+      <page size='1048576' unit='KiB'/>
+    </hugepages>
+    </memoryBacking>
+    ```
+
 ## Use ovs_modules
 You can use the python/example.py script in order to use ovs modules  
 The script creates netdev bridge and vdpa port on the container,


### PR DESCRIPTION
memoryBacking element with hugepages influence how virtual memory pages
are backed by host pages.
The new configuration inside the xml tells the hypervisor that the guest
should have its memory allocated using hugepages instead of the normal
native page size.

Signed-off-by: Waleedm Mousa <waleedm@nvidia.com>