### PR TITLE
Add nova change to set the mtu for vdpa port in vm xml file in victoria

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,15 +228,10 @@ To enable debug in ovs inside the container, you can run the following command i
     tcpdump -i ens4f0 -nev icmp &
     ping 11.100.126.1 -s 9188 -M do -c 1
     ```
-  - Enable host_mtu in xml add the following values to xml 
+  - Set the mtu size in the xml file
     ```
-    <domain type='kvm' id='21' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
-    <qemu:commandline>
-    <qemu:arg value='-set'/>
-    <qemu:arg value='device.net1.host_mtu=9216'/>
-    </qemu:commandline>
+    <mtu size='9216'/>
     ```
-    * net1 is the alias name of the interface (it can be found by virsh dumpxml command)
   - Add mtu_request=9216 option to the OvS ports inside the container and restart the OvS:
     ```
     ovs-vsctl set port vdpa0 mtu_request=9216
@@ -250,14 +245,14 @@ To enable debug in ovs inside the container, you can run the following command i
     ```
 
 ## VM XML changes:
-  - Add page-per-vq for performance improvements
+  - Add page-per-vq for performance improvements and driver queues under interface configuration for balancing traffic between PFs in vf lag mode:  
     ```
-    <driver page_per_vq='on'/>
+    <driver queues='4' rx_queue_size='512' tx_queue_size='512' page_per_vq='on'/>
     ```
 
-  - Add driver queues under interface configuration for balancing traffic between PFs in vf lag mode:
+  - Add target dev with the name of the vf net device under interface configuration
     ```
-    <driver queues='8'/>
+    <target dev='enp3s0f0v7'/>
     ```
 
   - Add memoryBacking section to reduce memory consumed by ovs-vswitchd thread inside the docker: 

--- a/openstack/victoria/ovs-kernel/nova.patch
+++ b/openstack/victoria/ovs-kernel/nova.patch
@@ -51,41 +51,10 @@ index 0bfd87bb1e..e7c3c57593 100644
          obj = _get_vif_instance(
              vif,
 diff --git a/nova/virt/libvirt/config.py b/nova/virt/libvirt/config.py
-index ea525648b3..4505e180cb 100644
+index ea525648b3..6ee809aabf 100644
 --- a/nova/virt/libvirt/config.py
 +++ b/nova/virt/libvirt/config.py
-@@ -82,6 +82,30 @@ class LibvirtConfigObject(object):
-         return xml_str
- 
- 
-+class LibvirtConfigQemuCommandLine(LibvirtConfigObject):
-+
-+    def __init__(self, **kwargs):
-+        super(LibvirtConfigQemuCommandLine, self).__init__(
-+            root_name='commandline', ns_prefix="qemu",
-+            ns_uri='http://libvirt.org/schemas/domain/qemu/1.0',
-+            **kwargs)
-+        self.args = {}
-+        self.net_alias_name = ""
-+
-+    def format_dom(self):
-+        domain = super(LibvirtConfigQemuCommandLine, self).format_dom()
-+        for arg,value in self.args.items():
-+            set_arg = self._new_node("arg")
-+            set_arg.set("value", "-set")
-+            domain.append(set_arg)
-+            new_arg = self._new_node("arg")
-+            new_arg.set("value", "device.%s.%s=%s" % (self.net_alias_name,
-+                                                      arg, value))
-+            domain.append(new_arg)
-+
-+        return domain
-+
-+
- class LibvirtConfigCaps(LibvirtConfigObject):
- 
-     def __init__(self, **kwargs):
-@@ -1689,6 +1713,8 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
+@@ -1689,6 +1689,8 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
          self.vlan = None
          self.device_addr = None
          self.mtu = None
@@ -94,16 +63,17 @@ index ea525648b3..4505e180cb 100644
  
      def __eq__(self, other):
          if not isinstance(other, LibvirtConfigGuestInterface):
-@@ -1741,6 +1767,8 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
+@@ -1741,6 +1743,9 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
                  drv_elem.set('rx_queue_size', str(self.vhost_rx_queue_size))
              if self.vhost_tx_queue_size is not None:
                  drv_elem.set('tx_queue_size', str(self.vhost_tx_queue_size))
 +            if self.vdpa:
 +                drv_elem.set('page_per_vq', 'on')
++                dev.append(etree.Element("mtu", size=str(self.mtu)))
  
              if (drv_elem.get('name') or drv_elem.get('queues') or
                  drv_elem.get('rx_queue_size') or
-@@ -1773,6 +1801,9 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
+@@ -1773,6 +1778,9 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
              dev.append(etree.Element("source", type=self.vhostuser_type,
                                       mode=self.vhostuser_mode,
                                       path=self.vhostuser_path))
@@ -113,34 +83,6 @@ index ea525648b3..4505e180cb 100644
          elif self.net_type == "bridge":
              dev.append(etree.Element("source", bridge=self.source_dev))
              if self.script is not None:
-@@ -2749,6 +2780,7 @@ class LibvirtConfigGuest(LibvirtConfigObject):
-         self.idmaps = []
-         self.perf_events = []
-         self.launch_security = None
-+        self.qemu_args = []
- 
-     def _format_basic_props(self, root):
-         root.append(self._text_node("uuid", self.uuid))
-@@ -2832,6 +2864,10 @@ class LibvirtConfigGuest(LibvirtConfigObject):
-             devices.append(dev.format_dom())
-         root.append(devices)
- 
-+    def _format_qemu_args(self, root):
-+        for qemu_arg in self.qemu_args:
-+            root.append(qemu_arg.format_dom())
-+
-     def _format_idmaps(self, root):
-         if len(self.idmaps) == 0:
-             return
-@@ -2883,6 +2919,8 @@ class LibvirtConfigGuest(LibvirtConfigObject):
- 
-         self._format_sev(root)
- 
-+        self._format_qemu_args(root)
-+
-         return root
- 
-     def _parse_basic_props(self, xmldoc):
 diff --git a/nova/virt/libvirt/designer.py b/nova/virt/libvirt/designer.py
 index 3677ed5280..7fa6f288eb 100644
 --- a/nova/virt/libvirt/designer.py
@@ -166,42 +108,6 @@ index 3677ed5280..7fa6f288eb 100644
  
  def set_vif_mtu_config(conf, mtu):
      """Populate a LibvirtConfigGuestInterface instance
-diff --git a/nova/virt/libvirt/driver.py b/nova/virt/libvirt/driver.py
-index 5dca28f24c..c6765a9d57 100644
---- a/nova/virt/libvirt/driver.py
-+++ b/nova/virt/libvirt/driver.py
-@@ -4987,6 +4987,13 @@ class LibvirtDriver(driver.ComputeDriver):
- 
-         return dev
- 
-+    def _get_guest_qemu_commandline(self, net_alias, **kwargs):
-+        qemu_config = vconfig.LibvirtConfigQemuCommandLine()
-+        qemu_config.net_alias_name = net_alias
-+        qemu_config.args = kwargs
-+
-+        return qemu_config
-+
-     def _get_guest_config_meta(self, instance):
-         """Get metadata config for guest."""
- 
-@@ -6175,6 +6182,17 @@ class LibvirtDriver(driver.ComputeDriver):
-                 instance, vif, image_meta, flavor, virt_type,
-             )
-             guest.add_device(config)
-+            if vif.get("vnic_type") == network_model.VNIC_TYPE_VIRTIO_FORWARDER:
-+                if (vif.get("network") and vif.get("network").get("meta") and
-+                        vif.get("network").get("meta").get("mtu")):
-+
-+                    # As a workaround, we have to set mtu_host in xml file for
-+                    # virtio-forwarder interface, we may revist it if needed
-+                    args_dict = {"host_mtu": vif["network"]["meta"]["mtu"]}
-+                    qemu_args = self._get_guest_qemu_commandline(config.vhost_net_alias,
-+                                                                 **args_dict)
-+
-+                    guest.qemu_args.append(qemu_args)
- 
-         self._create_consoles(virt_type, guest, instance, flavor, image_meta)
- 
 diff --git a/nova/virt/libvirt/vif.py b/nova/virt/libvirt/vif.py
 index 5c87223baf..2b44b90daa 100644
 --- a/nova/virt/libvirt/vif.py


### PR DESCRIPTION
Set the mtu for vdpa ports using libvirt the xml file

    <interface type='vhostuser'>
      <mac address='fa:16:3e:85:aa:2e'/>
      <source type='unix' path='/var/lib/vhost_sockets/sock6bf767c0-7ec' mode='server'/>
      <target dev='enp3s0f0v7'/>
      <model type='virtio'/>
      <driver queues='4' rx_queue_size='512' tx_queue_size='512' page_per_vq='on'/>
      <mtu size='8942'/>
      <alias name='ua-vdpa-6bf767c0-7ec'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
    </interface>